### PR TITLE
Nucleus Burp Extension v1.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Nucleus Security
+Copyright (c) 2021 Nucleus Security
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.nucleussec</groupId>
     <artifactId>Nucleus-Burp-Extension</artifactId>
-    <version>1.0</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/nucleussec/burpextension/view/MainView.java
+++ b/src/main/java/com/nucleussec/burpextension/view/MainView.java
@@ -114,7 +114,9 @@ public class MainView extends javax.swing.JPanel {
     
     private void zipFile(File file) {
         try {
-            FileOutputStream fos = new FileOutputStream(System.getenv("USERPROFILE")+"\\AppData\\Local\\Temp\\" + file.getName()+".zip");
+            String osTempDir = System.getProperty("java.io.tmpdir");
+            String fileName = osTempDir + File.separator + file.getName() + ".zip";
+            FileOutputStream fos = new FileOutputStream(fileName);
             ZipOutputStream zipOut = new ZipOutputStream(fos);
             FileInputStream fis = new FileInputStream(file);
             ZipEntry zipEntry = new ZipEntry(file.getName());


### PR DESCRIPTION
- Fixed issue with *nix-based systems not zipping Burp reports correctly
